### PR TITLE
術語詞彙對照

### DIFF
--- a/src/terms/zh_CN.json
+++ b/src/terms/zh_CN.json
@@ -131,6 +131,12 @@
     "user": "用戶",
     "variable": "變量",
     "video": "視頻",
-    "window": "窗口"
+    "window": "窗口",
+    "parameter": "形參",
+    "interpreter": "解釋器",
+    "algorithm": "算法",
+    "string": "字串符",
+    "store": "存儲",
+    "operator": "操作符"
   }
 }

--- a/src/terms/zh_TW.json
+++ b/src/terms/zh_TW.json
@@ -131,6 +131,12 @@
     "user": "使用者",
     "variable": "變數",
     "video": "影片",
-    "window": "視窗"
+    "window": "視窗",
+    "parameter": "參數",
+    "interpreter": "直譯器",
+    "algorithm": "演算法",
+    "string": "字串",
+    "store": "儲存",
+    "operator": "運算子"
   }
 }


### PR DESCRIPTION
補充術語為瀏覽阮一峰[部落格](http://www.ruanyifeng.com/blog/)時所見到還未轉譯之詞彙。

補充對照則參考自 [大陸台灣計算機術語對照表](https://zh.wikibooks.org/zh-tw/%E5%A4%A7%E9%99%86%E5%8F%B0%E6%B9%BE%E8%AE%A1%E7%AE%97%E6%9C%BA%E6%9C%AF%E8%AF%AD%E5%AF%B9%E7%85%A7%E8%A1%A8)，並挑選幾個較常用到的字彙補充進去。